### PR TITLE
Fixing styled-components error.

### DIFF
--- a/src/components/CheckoutPayment.js
+++ b/src/components/CheckoutPayment.js
@@ -59,6 +59,6 @@ const SummaryText = styled.div`
 
 const TotalText = styled.div`
   font-size: 1.2em;
-  font-weight: bold
+  font-weight: bold;
   color: #B12704;
 `

--- a/src/components/CheckoutSummary.js
+++ b/src/components/CheckoutSummary.js
@@ -80,6 +80,6 @@ const NormalText = styled.div`
 `
 const TotalText = styled.div`
   font-size: 1.2em;
-  font-weight: bold
+  font-weight: bold;
   color: #B12704;
 `


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The CheckoutPayment.js and CheckoutSummary.js files were both missing a semicolon needed for styled-components.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
