### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/amplify/backend/analytics/awsamplifyecommerce/pinpoint-cloudformation-template.json
+++ b/amplify/backend/analytics/awsamplifyecommerce/pinpoint-cloudformation-template.json
@@ -199,7 +199,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs10.x",
+                "Runtime": "nodejs14.x",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/amplify/backend/auth/awsamplifyecommerceauth/awsamplifyecommerceauth-cloudformation-template.yml
+++ b/amplify/backend/auth/awsamplifyecommerceauth/awsamplifyecommerceauth-cloudformation-template.yml
@@ -315,7 +315,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/function/lambdaitems/lambdaitems-cloudformation-template.json
+++ b/amplify/backend/function/lambdaitems/lambdaitems-cloudformation-template.json
@@ -67,7 +67,7 @@
 						"Arn"
 					]
 				},
-				"Runtime": "nodejs10.x",
+				"Runtime": "nodejs14.x",
 				"Timeout": "25",
 				"Code": {
 					"S3Bucket": "amplify-awsamplifyecommerce-alpha-235957-deployment",


### PR DESCRIPTION
CloudFormation templates in aws-amplify-ecommerce have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.